### PR TITLE
Add ScholarshipOps reminder automation

### DIFF
--- a/.github/workflows/remind.yml
+++ b/.github/workflows/remind.yml
@@ -1,0 +1,45 @@
+name: ScholarshipOps - Reminders
+
+on:
+  schedule:
+    - cron: "10 4 * * 1-5"    # Mon-Fri 12:10 Asia/Taipei
+    - cron: "10 13 * * 1-5"   # Mon-Fri 21:10 Asia/Taipei
+    - cron: "0 2 * * 6,0"     # Sat/Sun 10:00 Asia/Taipei
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: scholarshipops-remind
+  cancel-in-progress: false
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install deps
+        run: pip install -r requirements.txt
+
+      - name: Send reminder
+        env:
+          TZ: Asia/Taipei
+          EVENT_SCHEDULE: ${{ github.event.schedule }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+
+          # Optional push channels:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+
+          # Optional: create daily issue
+          CREATE_ISSUE: "true"
+        run: python scripts/remind.py

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# ScholarshipOps automation
+
+This repository automates scholarship reminder pushes (lunch, evening, weekend) via GitHub Actions and optional Telegram/Slack notifications. It also supports a GitHub-issue-only fallback for mobile push notifications.
+
+## Schedule (Asia/Taipei)
+
+| Reminder | Local time | UTC cron |
+| --- | --- | --- |
+| Lunch | 12:10 | `10 4 * * 1-5` |
+| Evening | 21:10 | `10 13 * * 1-5` |
+| Weekend | 10:00 | `0 2 * * 6,0` |
+
+The workflow always runs on the default branch with the latest commit, as required by GitHub Actions scheduled events.
+
+## Secrets
+
+Configure secrets in **Settings → Secrets and variables → Actions**.
+
+### Telegram (recommended)
+
+- `TELEGRAM_BOT_TOKEN`
+- `TELEGRAM_CHAT_ID`
+
+### Slack (optional)
+
+- `SLACK_WEBHOOK_URL`
+
+## GitHub-only fallback
+
+The workflow can create daily issues to trigger GitHub mobile notifications. This is controlled by `CREATE_ISSUE` in the workflow.
+
+## Files
+
+- `.github/workflows/remind.yml`: schedule + run the reminder script.
+- `scripts/remind.py`: load tasks, format messages, send pushes.
+- `tasks/daily_2026-01-18_to_02-10.yml`: daily plan.
+- `tasks/phases_2026-02-11_to_06-01.yml`: phase-based cadence through 2026-06-01.
+- `tasks/deadlines.yml`: upcoming deadlines for D-21 style reminders.
+
+## Updating
+
+- Daily changes: edit the YAML files under `tasks/` and push.
+- Weekly: update `tasks/deadlines.yml` with new confirmed deadlines.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+PyYAML==6.0.2
+requests==2.32.3
+python-dateutil==2.9.0.post0

--- a/scripts/remind.py
+++ b/scripts/remind.py
@@ -1,0 +1,143 @@
+import os
+import datetime as dt
+from dateutil import tz
+import requests
+import yaml
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+
+
+def load_yaml(relpath: str) -> dict:
+    with open(os.path.join(ROOT, relpath), "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def today_taipei() -> dt.date:
+    tpe = tz.gettz("Asia/Taipei")
+    return dt.datetime.now(tpe).date()
+
+
+def detect_mode(event_schedule: str | None) -> str:
+    if not event_schedule:
+        return "manual"
+    if event_schedule.strip() == "10 4 * * 1-5":
+        return "lunch"
+    if event_schedule.strip() == "10 13 * * 1-5":
+        return "evening"
+    if event_schedule.strip() == "0 2 * * 6,0":
+        return "weekend"
+    return "unknown"
+
+
+def pick_tasks(date_str: str, mode: str) -> dict:
+    daily = load_yaml("tasks/daily_2026-01-18_to_02-10.yml")
+    phases = load_yaml("tasks/phases_2026-02-11_to_06-01.yml")
+
+    if date_str in daily.get("days", {}):
+        return daily["days"][date_str].get(mode, daily["days"][date_str].get("default", {}))
+
+    d = dt.date.fromisoformat(date_str)
+    for ph in phases.get("phases", []):
+        start = dt.date.fromisoformat(ph["start"])
+        end = dt.date.fromisoformat(ph["end"])
+        if start <= d <= end:
+            key = "weekend" if mode == "weekend" else "weekday"
+            return ph.get(key, {})
+    return {
+        "title": "No tasks configured",
+        "todo": ["Update your phases/tasks files"],
+        "deliverable": "",
+    }
+
+
+def upcoming_deadlines(date_str: str, horizon_days: int = 21) -> list[dict]:
+    d0 = dt.date.fromisoformat(date_str)
+    d1 = d0 + dt.timedelta(days=horizon_days)
+    dd = load_yaml("tasks/deadlines.yml").get("deadlines", [])
+    out = []
+    for item in dd:
+        due = dt.date.fromisoformat(item["date"])
+        if d0 <= due <= d1:
+            out.append({**item, "d_minus": (due - d0).days})
+    out.sort(key=lambda x: x["d_minus"])
+    return out
+
+
+def format_message(date_str: str, mode: str, task: dict, deadlines: list[dict]) -> str:
+    mode_label = {
+        "lunch": "Lunch 10m (Inbox / Deadline / 待辦更新)",
+        "evening": "Evening 50–65m 深工（寫作/送件/材料整理）",
+        "weekend": "Weekend 2.5–4h 深工（完成一整份申請/材料包升級）",
+        "manual": "Manual run",
+    }.get(mode, mode)
+
+    lines = []
+    lines.append(f"[ScholarshipOps] {date_str} — {mode_label}")
+    if task.get("title"):
+        lines.append(f"- Focus: {task['title']}")
+    todo = task.get("todo", [])
+    if todo:
+        lines.append("- Today TODO:")
+        for i, t in enumerate(todo, 1):
+            lines.append(f"  {i}. {t}")
+    if task.get("deliverable"):
+        lines.append(f"- Deliverable: {task['deliverable']}")
+
+    if deadlines:
+        lines.append("")
+        lines.append("Upcoming deadlines (next 21d):")
+        for it in deadlines[:8]:
+            lines.append(f"- D-{it['d_minus']:02d} {it['name']} ({it['date']})")
+
+    return "\n".join(lines)
+
+
+def send_slack(webhook_url: str, text: str) -> None:
+    r = requests.post(webhook_url, json={"text": text}, timeout=15)
+    r.raise_for_status()
+
+
+def send_telegram(token: str, chat_id: str, text: str) -> None:
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    r = requests.post(url, data={"chat_id": chat_id, "text": text}, timeout=15)
+    r.raise_for_status()
+
+
+def create_github_issue(repo: str, gh_token: str, title: str, body: str) -> None:
+    api = f"https://api.github.com/repos/{repo}/issues"
+    headers = {"Authorization": f"Bearer {gh_token}", "Accept": "application/vnd.github+json"}
+    r = requests.post(api, headers=headers, json={"title": title, "body": body}, timeout=15)
+    r.raise_for_status()
+
+
+def main() -> None:
+    date_str = today_taipei().isoformat()
+    mode = detect_mode(os.getenv("EVENT_SCHEDULE"))
+    task = pick_tasks(date_str, mode)
+    dd = upcoming_deadlines(date_str, horizon_days=21)
+    msg = format_message(date_str, mode, task, dd)
+
+    slack = os.getenv("SLACK_WEBHOOK_URL", "").strip()
+    t_token = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
+    t_chat = os.getenv("TELEGRAM_CHAT_ID", "").strip()
+
+    sent = False
+    if t_token and t_chat:
+        send_telegram(t_token, t_chat, msg)
+        sent = True
+    if slack:
+        send_slack(slack, msg)
+        sent = True
+
+    if os.getenv("CREATE_ISSUE", "false").lower() == "true":
+        repo = os.getenv("REPO", "").strip()
+        gh_token = os.getenv("GH_TOKEN", "").strip()
+        if repo and gh_token:
+            create_github_issue(repo, gh_token, f"{date_str} [{mode}] ScholarshipOps", msg)
+
+    if not sent:
+        print(msg)
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/daily_2026-01-18_to_02-10.yml
+++ b/tasks/daily_2026-01-18_to_02-10.yml
@@ -1,0 +1,161 @@
+days:
+  "2026-01-18":
+    weekend:
+      title: "建立 Scholarship Data Room"
+      todo:
+        - "整理：Offer letter、成績單、CV、證照、作品集連結、護照/身分證掃描"
+        - "英文姓名一致性檢查（護照/offer/成績單/各平台）"
+      deliverable: "資料夾完成 + 檔名規則統一"
+  "2026-01-19":
+    lunch:
+      title: "Inbox/Deadline/待辦更新"
+      todo: ["更新 tracker 狀態欄位、清空 1 個阻塞點"]
+      deliverable: "tracker 更新"
+    evening:
+      title: "獎學金管線表 Tracker v1"
+      todo:
+        - "建欄位：名稱/金額/用途限制/資格/材料/截止/狀態/下一步"
+      deliverable: "Tracker v1"
+  "2026-01-20":
+    evening:
+      title: "Studyportals motivation letter 定稿"
+      todo:
+        - "400–600 words"
+        - "對齊：Ambition/Personality/Originality/Clarity/Length"
+      deliverable: "Studyportals ML vFinal"
+  "2026-01-21":
+    evening:
+      title: "Studyportals upload-ready"
+      todo:
+        - "acceptance letter PDF + ML PDF"
+        - "做一次提交演練"
+      deliverable: "upload-ready"
+  "2026-01-22":
+    evening:
+      title: "ASQ Freund checklist"
+      todo:
+        - "確認 eligibility + 建資料夾 + 缺口清單"
+      deliverable: "ASQ checklist"
+  "2026-01-23":
+    evening:
+      title: "ASQ essay v1"
+      todo: ["先完成 60%，不追求完美"]
+      deliverable: "ASQ essay v1"
+  "2026-01-24":
+    weekend:
+      title: "週末衝刺 #1（ASQ pack 70%）"
+      todo:
+        - "ASQ essay v2"
+        - "推薦人清單 2 位 + 請託信草稿"
+      deliverable: "ASQ pack 70%"
+  "2026-01-25":
+    weekend:
+      title: "Studyportals 正式提交 + 備份"
+      todo:
+        - "正式提交（若 offer 已到手）"
+        - "備份所有提交檔 + tracker 更新"
+      deliverable: "Studyportals submitted + log"
+  "2026-01-26":
+    evening:
+      title: "ISACA essays set v1"
+      todo:
+        - "通用母文拆 3 組短文：Why you/Why need/Goals"
+      deliverable: "ISACA essays set v1"
+  "2026-01-27":
+    evening:
+      title: "Evidence bullets v1"
+      todo:
+        - "整理 3–5 個量化戰績 + 作品連結（digital trust 對齊）"
+      deliverable: "Evidence bullets v1"
+  "2026-01-28":
+    evening:
+      title: "Rotary alignment 1頁"
+      todo: ["對齊 Areas of Focus（Supporting education / Peace 等）"]
+      deliverable: "Rotary alignment 1頁"
+  "2026-01-29":
+    evening:
+      title: "Sponsor list + 1-pager"
+      todo:
+        - "列 10 個 sponsor clubs（台灣 + UK/Scotland）"
+        - "做可寄版 1 頁摘要"
+      deliverable: "Sponsor list + 1-pager"
+  "2026-01-30":
+    evening:
+      title: "GSoC target list"
+      todo:
+        - "鎖定 2–3 個 org/專案（2 週內能出 PR）"
+        - "建立 onboarding 待辦"
+      deliverable: "GSoC target list"
+  "2026-01-31":
+    weekend:
+      title: "週末衝刺 #2（第一個可被接受的貢獻）"
+      todo:
+        - "做 doc/test/小 bug"
+        - "社群打招呼、確認 issue"
+      deliverable: "1st contribution ready"
+  "2026-02-01":
+    weekend:
+      title: "Recommender kit"
+      todo:
+        - "推薦信請託信完成"
+        - "essay 變成 1 頁 summary（給推薦人參考）"
+      deliverable: "Recommender kit"
+  "2026-02-02":
+    evening:
+      title: "ASQ gaps 50% closed"
+      todo:
+        - "把缺口清單清空一半（transcript/CV/作品集補強等）"
+      deliverable: "ASQ gaps 50% closed"
+  "2026-02-03":
+    evening:
+      title: "GSoC log v1"
+      todo:
+        - "備份 org 名單與貢獻紀錄"
+      deliverable: "GSoC log v1"
+  "2026-02-04":
+    evening:
+      title: "ISACA essays v2"
+      todo:
+        - "精簡、對題、可複用"
+        - "整理學費/生活費缺口敘事"
+      deliverable: "ISACA essays v2"
+  "2026-02-05":
+    evening:
+      title: "第三方獎學金搜尋 sprint（+5 leads）"
+      todo:
+        - "只收：可用於 UK master / open international / 不綁國籍"
+        - "新增 5 個合格 lead 到 tracker"
+      deliverable: "+5 leads"
+  "2026-02-06":
+    evening:
+      title: "Rotary outreach"
+      todo: ["寄出 3 封 sponsor outreach（或完成 3 封可寄草稿）"]
+      deliverable: "3 outreach sent/drafted"
+  "2026-02-07":
+    weekend:
+      title: "週末衝刺 #3（ASQ pack 95%）"
+      todo:
+        - "essay 最終版"
+        - "推薦人確認"
+        - "附件整理"
+      deliverable: "ASQ pack 95%"
+  "2026-02-08":
+    weekend:
+      title: "ISACA ready-to-submit"
+      todo:
+        - "建立 3 月開放後 48 小時內可送件的一鍵包"
+      deliverable: "ISACA ready-to-submit"
+  "2026-02-09":
+    evening:
+      title: "Tracker 清潔"
+      todo:
+        - "再新增 5 leads"
+        - "前 10 leads 快速淘汰（不符就刪）"
+      deliverable: "Tracker cleaned"
+  "2026-02-10":
+    evening:
+      title: "Q1 plan v1"
+      todo:
+        - "排 2/10 後到 4/1、3 月（ISACA 開放）週計畫"
+        - "設定提醒"
+      deliverable: "Q1 plan v1"

--- a/tasks/deadlines.yml
+++ b/tasks/deadlines.yml
@@ -1,0 +1,7 @@
+deadlines:
+  - name: "ASQ - Richard A. Freund (example)"
+    date: "2026-04-01"
+  - name: "Studyportals (example)"
+    date: "2026-05-31"
+  - name: "GSoC contributors application window (official)"
+    date: "2026-03-31"

--- a/tasks/phases_2026-02-11_to_06-01.yml
+++ b/tasks/phases_2026-02-11_to_06-01.yml
@@ -1,0 +1,62 @@
+phases:
+  - name: "Phase A: 申請材料穩定化 + 管線擴張"
+    start: "2026-02-11"
+    end: "2026-03-15"
+    weekday:
+      title: "Weekday cadence（60–75m）"
+      todo:
+        - "Mon：tracker/截止/阻塞點清空（10m + 50m）"
+        - "Tue：essay/ML 通用母文迭代（60m）"
+        - "Wed：第三方獎學金 lead 搜尋 + eligibility 淘汰（60m）"
+        - "Thu：outreach / follow-up（推薦人、sponsor、基金會窗口）（60m）"
+        - "Fri：附件與 Data Room 維護（命名、版本、PDF 合併）（60m）"
+      deliverable: "每週新增 ≥10 leads、提交/可提交件數 ≥1"
+    weekend:
+      title: "Weekend deep work（2.5–4h）"
+      todo:
+        - "完成 1 份完整申請（或把一份申請推進到 90%）"
+        - "作品集/成就量化 bullets 更新（含連結）"
+      deliverable: "每週至少 1 個『可送件』包"
+
+  - name: "Phase B: GSoC 提案窗口（若你要把 GSoC 當資金/履歷槓桿）"
+    start: "2026-03-16"
+    end: "2026-03-31"
+    weekday:
+      title: "GSoC sprint（晚間深工）"
+      todo:
+        - "Mon/Tue：proposal 版本迭代 + 對 org mentor 校稿"
+        - "Wed：補 1–2 個高品質 PR（可被 merge）"
+        - "Thu：proposal 最終化 + 風險清單/里程碑"
+        - "Fri：提交前 QA（格式、字數、連結、可驗證成果）"
+      deliverable: "proposal ready + 至少 2 個可驗證貢獻"
+    weekend:
+      title: "GSoC weekend deep work"
+      todo:
+        - "整合提案、做 demo/測試、補文件"
+      deliverable: "proposal submitted"
+
+  - name: "Phase C: 4 月（ASQ/其他第三方主戰場 + follow-up）"
+    start: "2026-04-01"
+    end: "2026-04-30"
+    weekday:
+      title: "Submission + Follow-up month"
+      todo:
+        - "Mon：回顧/補缺件"
+        - "Tue：送件/補件"
+        - "Wed：lead 搜尋（只收高勝率）"
+        - "Thu：follow-up（所有已投）"
+        - "Fri：財務缺口敘事與預算表更新（可重用）"
+      deliverable: "每週至少 1 件送出 or 2 件推進到可送"
+
+  - name: "Phase D: 5 月–6/01（維持投遞節奏 + 等結果/補件）"
+    start: "2026-05-01"
+    end: "2026-06-01"
+    weekday:
+      title: "Maintain & respond"
+      todo:
+        - "Mon：截止盤點 + 本週優先序"
+        - "Tue：材料包維護（CV/ML/Portfolio/證明）"
+        - "Wed：新增 leads（≥5）"
+        - "Thu：follow-up + 面談/補件準備"
+        - "Fri：備援資金方案文件化（可被審查的資金證明路徑）"
+      deliverable: "保持每週 ≥1 推進交付物"


### PR DESCRIPTION
### Motivation
- Provide a reproducible reminder automation for a scholarship application cadence (daily lunch/evening and weekend reminders) that runs via GitHub Actions and can push notifications to Telegram or Slack or fall back to GitHub issues. 
- Keep the schedule sustainable through `2026-06-01` using a per-day YAML plan for 2026-01-18→02-10 and a phase-based cadence for 2026-02-11→06-01.

### Description
- Add a scheduled workflow ` .github/workflows/remind.yml` that runs on UTC cron times for lunch/evening/weekend and exposes optional secrets `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, and `SLACK_WEBHOOK_URL`. 
- Implement `scripts/remind.py` which loads YAML task files, detects which reminder triggered the run, formats a message including upcoming deadlines, and delivers it via Telegram (`sendMessage`), Slack (Incoming Webhook), or creates a GitHub issue as a fallback. 
- Add structured task data files `tasks/daily_2026-01-18_to_02-10.yml`, `tasks/phases_2026-02-11_to_06-01.yml`, and `tasks/deadlines.yml` to drive per-day and phase-based reminders. 
- Add `requirements.txt` for dependencies and `README.md` documenting schedule, secrets, usage, and file layout. 

### Testing
- No automated tests were run for this change (content/configuration and new script added, workflow will run on schedule or via `workflow_dispatch`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ca62aae98832585ef6e0f13fa3b27)