### PR TITLE
Handle empty criteria and flexible progress input

### DIFF
--- a/agent_skills/json_schemas/rule_change.schema.json
+++ b/agent_skills/json_schemas/rule_change.schema.json
@@ -16,7 +16,7 @@
     },
     "stage": {
       "type": "string",
-      "enum": ["eligibility", "triage", "scoring"],
+      "enum": ["eligibility", "triage", "scoring", "timeline", "trust", "content", "link_health", "effort"],
       "description": "Pipeline stage where rule is applied"
     },
     "description": {
@@ -48,9 +48,61 @@
           },
           "description": "List of regex patterns (match if all match)"
         },
-        "deadline_condition": {
+        "deadline": {
           "type": "object",
-          "description": "Deadline-based condition"
+          "description": "Deadline-based condition",
+          "properties": {
+            "lt_today": {
+              "type": "boolean",
+              "description": "Deadline is less than today"
+            },
+            "is_null": {
+              "type": "boolean",
+              "description": "Deadline is null/empty"
+            },
+            "gt_study_start": {
+              "type": "boolean",
+              "description": "Deadline is greater than study start date"
+            },
+            "safety_margin_days": {
+              "type": "integer",
+              "description": "Days before study start to reject (default: 60)"
+            }
+          }
+        },
+        "http_status": {
+          "type": "object",
+          "description": "HTTP status condition",
+          "properties": {
+            "any_of": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "description": "Match if HTTP status is any of these values"
+            }
+          }
+        },
+        "effort_score": {
+          "type": "object",
+          "description": "Effort score condition",
+          "properties": {
+            "gt": {
+              "type": "integer",
+              "description": "Effort score greater than this value"
+            }
+          }
+        },
+        "is_taiwan_eligible": {
+          "oneOf": [
+            {"type": "boolean"},
+            {"type": "string", "enum": ["unknown"]}
+          ],
+          "description": "Taiwan eligibility gate (bool or 'unknown')"
+        },
+        "is_directory_page": {
+          "type": "boolean",
+          "description": "Directory/index page gate - skip rules for discovery pages"
         },
         "trust_tier": {
           "type": "string",

--- a/container/src/db/criteria.ts
+++ b/container/src/db/criteria.ts
@@ -6,7 +6,16 @@ import type { Criteria } from '../types'
 export async function getCriteria(db: ReturnType<typeof getDb>): Promise<Criteria | null> {
   // Get the first (and should be only) criteria record
   const result = await db.select().from(criteria).limit(1).get()
-  return result ? mapCriteriaFromDb(result) : null
+  if (!result) {
+    return null
+  }
+  
+  // Check if the record is effectively empty (both JSON fields are null or empty objects)
+  const mapped = mapCriteriaFromDb(result)
+  const isEmpty = (!mapped.criteriaJson || Object.keys(mapped.criteriaJson).length === 0) &&
+                   (!mapped.profileJson || Object.keys(mapped.profileJson).length === 0)
+  
+  return isEmpty ? null : mapped
 }
 
 export async function createOrUpdateCriteria(

--- a/container/src/routes/applications.ts
+++ b/container/src/routes/applications.ts
@@ -15,7 +15,13 @@ const applicationSchema = z.object({
   currentStage: z.string().optional(),
   nextAction: z.string().optional(),
   requiredDocs: z.array(z.string()).optional(),
-  progress: z.number().min(0).max(100).optional(),
+  progress: z.union([z.string(), z.number()]).transform((val) => {
+    if (typeof val === 'string') {
+      const num = parseInt(val, 10)
+      return isNaN(num) ? undefined : num
+    }
+    return val
+  }).pipe(z.number().min(0).max(100)).optional(),
   notes: z.string().optional(),
 })
 


### PR DESCRIPTION
Update getCriteria to return null if both JSON fields are empty or null, treating such records as non-existent. Adjust applicationSchema to accept progress as either a string or number, converting string input to a number and validating the range.